### PR TITLE
Adds Scala 2.13.1 version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,16 +2,16 @@ name := "vtdxml4s"
 
 organization := "com.github.springernature"
 
-crossScalaVersions := Seq("2.12.3", "2.11.7")
+crossScalaVersions := Seq("2.12.3", "2.11.7", "2.13.1")
 
 scalaVersion := crossScalaVersions.value.head
 
 scalacOptions ++= Seq("-deprecation", "-feature", "-Xfatal-warnings")
 
 libraryDependencies ++= Seq(
-    "org.scala-lang.modules" %% "scala-xml" % "1.0.5",
+    "org.scala-lang.modules" %% "scala-xml" % "1.3.0",
     "com.ximpleware" % "vtd-xml" % "2.13.4",
-    "org.scalatest" %% "scalatest" % "3.0.0" % "test"
+    "org.scalatest" %% "scalatest" % "3.1.0" % "test"
   )
 
 publishTo := {

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.9
+sbt.version=1.3.9

--- a/src/main/scala/com/springer/link/shared/xml/VtdXml.scala
+++ b/src/main/scala/com/springer/link/shared/xml/VtdXml.scala
@@ -261,7 +261,7 @@ object VtdXml {
       }
     }
 
-    override def mkString = new String(payload)
+    def makeString = new String(payload)
 
     override def toString(): String = text
 

--- a/src/test/scala/com/springer/link/shared/xml/VtdNodeSeqTest.scala
+++ b/src/test/scala/com/springer/link/shared/xml/VtdNodeSeqTest.scala
@@ -4,14 +4,14 @@ import java.nio.charset.StandardCharsets
 import java.util.concurrent.{ExecutorService, Executors, TimeUnit}
 
 import com.springer.link.shared.xml.VtdXml.{NodeSeqPool, VtdElem, VtdNodeSeq}
-import org.scalatest.FunSpec
-import org.scalatest.Matchers._
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.collection.immutable.Seq
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, ExecutionContext, Future}
 
-class VtdNodeSeqTest extends FunSpec {
+class VtdNodeSeqTest extends AnyFunSpec with Matchers {
   val elem = <a>
     <title modifier="very">hello <b>bold</b> sam</title>
     <title2 modifier="very">hello <b><c>bold</c></b> curious <b>silly</b> sam</title2>
@@ -194,7 +194,7 @@ class VtdNodeSeqTest extends FunSpec {
     seq.text.split("\n").map(_.trim()).mkString shouldBe "onetwothree"
     seq.iterator.next().text /*..split("\n").map(_.trim()).mkString */ shouldBe "onetwothree" // "\n      one\n      two\n      three\n    "
 
-    seq.mkString shouldBe "<list>\n      <item>one</item>\n      <item modifier=\"hello\">two</item>\n      <item>three</item>\n    </list>"
+    seq.makeString shouldBe "<list>\n      <item>one</item>\n      <item modifier=\"hello\">two</item>\n      <item>three</item>\n    </list>"
     (seq \\ "@modifier").text shouldBe "hello"
 
     (doc \ "list" \\ "@modifier").exists(n => n.exists(_.text == "hello")) shouldBe true
@@ -212,7 +212,7 @@ class VtdNodeSeqTest extends FunSpec {
         <b>3</b>
     </a>)
 
-    val bs = (elem \\ "b").map(x => x.mkString)
+    val bs = (elem \\ "b").map(x => x.makeString)
 
     bs.length shouldBe 3
     bs.filterNot(_ == "").length shouldBe 3
@@ -228,7 +228,7 @@ class VtdNodeSeqTest extends FunSpec {
         |</a>
       """.stripMargin)
 
-    val bs = (elem \\ "b").map(x => x.mkString)
+    val bs = (elem \\ "b").map(x => x.makeString)
 
     bs.length shouldBe 3
   }
@@ -263,7 +263,7 @@ class VtdNodeSeqTest extends FunSpec {
     seq.head.text shouldBe "hello bold curious silly sam"
 
     seq.map(_.text).mkString shouldBe "hello bold curious silly sam"
-    seq.mkString shouldBe "<title2 modifier=\"very\">hello <b><c>bold</c></b> curious <b>silly</b> sam</title2>"
+    seq.makeString shouldBe "<title2 modifier=\"very\">hello <b><c>bold</c></b> curious <b>silly</b> sam</title2>"
   }
 
 


### PR DESCRIPTION
In the ContentUsage team we're using vtdxml4s for A++ parsing and we thought about moving our project to Scala 2.13.x. vtdxml4s is the only library which doesn't provide 2.13 support.

Additionally I've updated dependencies to make it work.

The only thing that I'm not sure is `mkString` method name change. There was compilation error for overwriting final mkString that belongs to scala.immutable.Seq
